### PR TITLE
network.py: minor pigeonhole API compat changes

### DIFF
--- a/.github/workflows/alembic-check.yml
+++ b/.github/workflows/alembic-check.yml
@@ -13,6 +13,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '>=1.26'
+          cache: false
+
       - name: Install uv
         uses: astral-sh/setup-uv@v3
         with:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -13,6 +13,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '>=1.26'
+          cache: false
+
       - name: Install uv
         uses: astral-sh/setup-uv@v3
         with:

--- a/Makefile
+++ b/Makefile
@@ -218,7 +218,7 @@ test-pip: $(STAMP_PIP)
 	@$(VENV)/bin/pytest
 
 $(KATZENPOST_DIR):
-	@git clone --branch new_pigeonhole_thinclient2_api_updates1 --depth 1 $(KATZENPOST_URL) $(KATZENPOST_DIR) >/dev/null 2>&1
+	@git clone $(KATZENPOST_URL) $(KATZENPOST_DIR) >/dev/null 2>&1
 
 katzenpost-update: $(KATZENPOST_DIR)
 	@cd $(KATZENPOST_DIR) && git pull --ff-only >/dev/null 2>&1

--- a/Makefile
+++ b/Makefile
@@ -218,7 +218,7 @@ test-pip: $(STAMP_PIP)
 	@$(VENV)/bin/pytest
 
 $(KATZENPOST_DIR):
-	@git clone $(KATZENPOST_URL) $(KATZENPOST_DIR) >/dev/null 2>&1
+	@git clone --branch new_pigeonhole_thinclient2_api_updates1 --depth 1 $(KATZENPOST_URL) $(KATZENPOST_DIR) >/dev/null 2>&1
 
 katzenpost-update: $(KATZENPOST_DIR)
 	@cd $(KATZENPOST_DIR) && git pull --ff-only >/dev/null 2>&1

--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ install-debian-packages:
 	@sudo apt install -y \
 		libxcb-cursor0 libegl1 libpulse0 \
 		build-essential pkg-config \
-		golang-go git podman \
+		git podman \
 		pipx python3 python3-venv >/dev/null
 
 install-uv:
@@ -234,9 +234,9 @@ kpclientd: $(KATZENPOST_DIR)
 	fi
 
 kpclientd-podman:
-	@cd $(KATZENPOST_DIR)/docker && make warped=false distro=debian \
-        voting_mixnet/kpclientd.debian && \
-        mv voting_mixnet/kpclientd.debian ../cmd/kpclientd/kpclientd
+	@cd $(KATZENPOST_DIR)/docker && make warped=false distro=bookworm \
+        voting_mixnet/kpclientd.bookworm && \
+        mv voting_mixnet/kpclientd.bookworm ../cmd/kpclientd/kpclientd
 
 install-kpclient: kpclientd
 	@install -d -m 0700 ~/.local/bin

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
 "aiosqlite~=0.21.0",
 "pydantic~=2.11.7",
 "cbor2~=5.6.5",
-"katzenpost_thinclient @ git+https://github.com/katzenpost/thin_client@update_python_pigeonhole"
+"katzenpost_thinclient @ git+https://github.com/katzenpost/thin_client@update_python_pigeonhole_pigeonhole_API_updates"
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
 "aiosqlite~=0.21.0",
 "pydantic~=2.11.7",
 "cbor2~=5.6.5",
-"katzenpost_thinclient @ git+https://github.com/katzenpost/thin_client@update_python_pigeonhole_pigeonhole_API_updates"
+"katzenpost_thinclient @ git+https://github.com/katzenpost/thin_client@update_python_pigeonhole"
 ]
 
 [dependency-groups]

--- a/src/katzenqt/network.py
+++ b/src/katzenqt/network.py
@@ -194,15 +194,15 @@ async def drain_mixwal_read_single(*, connection:ThinClient, rcw_read_cap: bytes
     assert idx_new == idx_old + 1, f"idx mismatch {idx_new} != {idx_old} + 1"
     rcw.next_index = mw.next_message_index
     sess.add(rcw)
-    if resp.startswith(b"I"):
+    if resp.plaintext.startswith(b"I"):
       logger.debug(f"received indirection {resp}")
       import pdb;pdb.set_trace()
       pass
-    elif resp.startswith(b"F"):
+    elif resp.plaintext.startswith(b"F"):
       # it's a discrete message
       logger.debug(f"received Final message {resp}")
       pass
-    elif resp.startswith(b"C"):
+    elif resp.plaintext.startswith(b"C"):
       logger.debug(f"received C message {resp}")
       pass
     else:
@@ -221,10 +221,10 @@ async def drain_mixwal_read_single(*, connection:ThinClient, rcw_read_cap: bytes
     sess.add(persistent.ReceivedPiece(
                 read_cap=mw.bacap_stream,
                 bacap_index=mw.current_message_index[:8],
-                chunk_type=resp[:1],
-                chunk=resp[1:]
+                chunk_type=resp.plaintext[:1],
+                chunk=resp.plaintext[1:]
             ))
-    cl = persistent.ConversationLog.append_from(cp, resp)
+    cl = persistent.ConversationLog.append_from(cp, resp.plaintext)
     sess.add(cl)
     await sess.delete(mw)
     c_id = cp.conversation.id


### PR DESCRIPTION
* Very minor editing of call sites to remain compatible with the new thinclient API changes.
* Fixup the github CI workflow so that it works. It broke because latest katzenpost requires go1.26