### PR TITLE
Stop selecting a courier client-side

### DIFF
--- a/src/katzenqt/migrations/versions/d08418a855a1_drop_mixwal_destination_column.py
+++ b/src/katzenqt/migrations/versions/d08418a855a1_drop_mixwal_destination_column.py
@@ -1,0 +1,31 @@
+"""drop mixwal destination column
+
+Revision ID: d08418a855a1
+Revises: 0711d7a23cd9
+Create Date: 2026-07-05 15:59:30.894376
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+import sqlmodel
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'd08418a855a1'
+down_revision: Union[str, Sequence[str], None] = '0711d7a23cd9'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    with op.batch_alter_table('mixwal', schema=None) as batch_op:
+        batch_op.drop_column('destination')
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    with op.batch_alter_table('mixwal', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('destination', sa.LargeBinary(), nullable=False))

--- a/src/katzenqt/network.py
+++ b/src/katzenqt/network.py
@@ -316,13 +316,6 @@ async def drain_mixwal_read_single(*, connection:ThinClient, rcw_read_cap: bytes
     readables_to_mixwal_event.set()
     return
 
-  # we should check that mw.destination exists:
-  if not courier_destination_exists(connection, mw.destination):
-      logger.error("outbound read mw for courier that no longer exists")
-      await asyncio.sleep(500)  # we want to wait until next PKI doc
-      give_up()
-      return
-
   try:
     resp = await connection.start_resending_encrypted_message(
         read_cap=rcw_read_cap,
@@ -583,9 +576,6 @@ async def drain_mixwal2(connection: ThinClient):
                 else:
                     new_write_mws.append(mw)
         for mw in new_write_mws:
-            if not courier_destination_exists(connection, mw.destination):
-                logger.warning("mw courier is currently not in PKI")
-                continue
             logger.debug("drain_mixwal: NEW (write) MIXWAL idx=%s is_read=%s bacap_stream=%s",
                          await connection.get_message_box_index_counter(mw.current_message_index),
                          mw.is_read, mw.bacap_stream)
@@ -639,12 +629,10 @@ async def readables_to_mixwal(connection):
         logger.debug("process box cpeer-rcw:", cpeer, await connection.get_message_box_index_counter(rcw.next_index))
         rcreply: "EncryptReadResult" = await connection.encrypt_read(read_cap=rcw.read_cap, message_box_index=rcw.next_index)
         logger.debug("process_box got this from encrypt_read: %s", rcreply)
-        courier: bytes = secrets.choice(katzenpost_thinclient.find_services("courier", connection.pki_document())).to_destination()[0]
         mw = persistent.MixWAL(
             bacap_stream=rcw.id,
             plaintextwal=None,
             envelope_hash=rcreply.envelope_hash,
-            destination=courier,
             encrypted_payload=rcreply.message_ciphertext,
             envelope_descriptor=rcreply.envelope_descriptor,
             next_message_index=rcreply.next_message_box_index,
@@ -812,12 +800,10 @@ async def start_resending(connection:ThinClient, pwal: persistent.PlaintextWAL):
 
     next_message_index = wcr.next_message_box_index
 
-    courier: bytes = secrets.choice(katzenpost_thinclient.find_services("courier", connection.pki_document())).to_destination()[0]
     mw = persistent.MixWAL(
         bacap_stream=pwal.bacap_stream,
         plaintextwal=pwal.id,
         envelope_hash = wcr.envelope_hash,
-        destination = courier,  # TODO not used anywhere
         encrypted_payload = wcr.message_ciphertext,
         envelope_descriptor = wcr.envelope_descriptor,
         current_message_index = wc.next_index,
@@ -981,23 +967,8 @@ def create_new_keypair(seed: bytes):
     assert len(read_cap)  == 32 + 104
     return write_cap, read_cap
 
-def courier_destination_exists(connection, destination) -> bool:
-    """Check that an old destination (hash of the IdentityKey) exists in this PKI, and that the node is a Courier.
-    We should not be resending MixWAL entries whose courier has gone away.
-
-    TODO: when ensuring courier exists we usually also want to make sure there are (some) replicas present.
-    """
-    try:
-        couriers = connection.get_all_couriers()
-    except Exception:
-        return False
-    return any(identity_hash == destination for identity_hash, _queue_id in couriers)
-
 async def test_keypair(connection, write_cap, read_cap):
     """Test that create_new_keypair() results in usable+matching write/read caps."""
-    courier = secrets.choice(katzenpost_thinclient.find_services("courier", connection.pki_document())).to_destination()[0]
-    logger.debug("courier exists? %s %s", courier, courier_destination_exists(connection, courier))
-
     wcr = await connection.encrypt_write(
         plaintext=b'hello',
         write_cap=write_cap,

--- a/src/katzenqt/persistent.py
+++ b/src/katzenqt/persistent.py
@@ -151,7 +151,6 @@ class MixWAL(SQLModel, table=True):
     bacap_stream: uuid.UUID = Field(unique=True) # There can only be one active write per stream
     # it can't be a foreign_key because we track ReadCapWAL+WriteCapWAL separately.
     envelope_hash: bytes = Field(unique=True)
-    destination: bytes  # courier this was supposed to be sent to
     encrypted_payload: bytes     # send_message_payload
     envelope_descriptor : bytes #  envelope private key
     current_message_index: bytes = Field(min_length=104, max_length=104)

--- a/tests/test_index_invariants.py
+++ b/tests/test_index_invariants.py
@@ -98,7 +98,6 @@ def _make_mw(
         bacap_stream=bacap_stream,
         plaintextwal=pwal_id,
         envelope_hash=envelope_hash or uuid.uuid4().bytes + b"\x00" * 16,
-        destination=b"C" * 32,
         encrypted_payload=b"ciphertext",
         envelope_descriptor=b"descriptor",
         current_message_index=mbi(current_idx),

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -1,13 +1,11 @@
 import asyncio
 import struct
-from unittest.mock import MagicMock
 
 import pytest
 
 from katzenqt import network
 from katzenqt.network import (
     check_for_new,
-    courier_destination_exists,
     create_new_keypair,
     on_connection_status,
     on_error,
@@ -47,44 +45,6 @@ def _restore_module_events():
             ev.set()
         else:
             ev.clear()
-
-
-class TestCourierDestinationExists:
-    """Tests for courier_destination_exists() using the new get_all_couriers() API."""
-
-    def _mock_connection(self, couriers):
-        conn = MagicMock()
-        conn.get_all_couriers.return_value = couriers
-        return conn
-
-    def test_matching_destination(self):
-        dest = b'\x01' * 32
-        conn = self._mock_connection([(dest, b'queue1')])
-        assert courier_destination_exists(conn, dest) is True
-
-    def test_non_matching_destination(self):
-        dest = b'\x01' * 32
-        other = b'\x02' * 32
-        conn = self._mock_connection([(other, b'queue1')])
-        assert courier_destination_exists(conn, dest) is False
-
-    def test_multiple_couriers(self):
-        dest = b'\x03' * 32
-        conn = self._mock_connection([
-            (b'\x01' * 32, b'q1'),
-            (b'\x02' * 32, b'q2'),
-            (dest, b'q3'),
-        ])
-        assert courier_destination_exists(conn, dest) is True
-
-    def test_empty_couriers(self):
-        conn = self._mock_connection([])
-        assert courier_destination_exists(conn, b'\x01' * 32) is False
-
-    def test_exception_returns_false(self):
-        conn = MagicMock()
-        conn.get_all_couriers.side_effect = Exception("no PKI")
-        assert courier_destination_exists(conn, b'\x01' * 32) is False
 
 
 class TestCreateNewKeypair:

--- a/tests/test_network_fake.py
+++ b/tests/test_network_fake.py
@@ -181,22 +181,6 @@ class TestFakeThinClientSurface:
 
 
 # ---------------------------------------------------------------------------
-# courier_destination_exists with the fake's PKI
-# ---------------------------------------------------------------------------
-
-
-class TestCourierDestinationExistsFakeBacked:
-    def test_default_courier_is_present(self, fake_thinclient):
-        dest = fake_thinclient.couriers[0][0]
-        assert network.courier_destination_exists(fake_thinclient, dest) is True
-
-    def test_missing_after_removal(self, fake_thinclient):
-        dest = fake_thinclient.couriers[0][0]
-        fake_thinclient.remove_courier(dest)
-        assert network.courier_destination_exists(fake_thinclient, dest) is False
-
-
-# ---------------------------------------------------------------------------
 # Scaffolding helpers for drain_mixwal_{write,read}_single
 # ---------------------------------------------------------------------------
 
@@ -569,24 +553,6 @@ class TestDrainMixwalReadSingle:
             assert log == []  # no append on stale ACK
 
     @pytest.mark.asyncio
-    async def test_courier_gone_pauses_and_gives_up(self, fake_thinclient):
-        setup = await _set_up_read_flow(fake_thinclient)
-        # Remove the courier so courier_destination_exists returns False.
-        fake_thinclient.remove_courier(fake_thinclient.couriers[0][0])
-        async with persistent.asession() as sess:
-            mw = await sess.get(persistent.MixWAL, setup["mw_id"])
-        draining: set = {setup["bacap_stream"]}
-        await network.drain_mixwal_read_single(
-            connection=fake_thinclient, rcw_read_cap=setup["read_cap"],
-            mw=mw, draining_right_now=draining,
-        )
-        # MW still present (we did not even try); start_resending never called.
-        async with persistent.asession() as sess:
-            assert await sess.get(persistent.MixWAL, setup["mw_id"]) is not None
-        assert fake_thinclient.call_count("start_resending_encrypted_message") == 0
-        assert setup["bacap_stream"] not in draining
-
-    @pytest.mark.asyncio
     async def test_bacap_decryption_failure_gives_up(self, fake_thinclient):
         setup = await _set_up_read_flow(fake_thinclient)
         fake_thinclient.inject_error(
@@ -952,42 +918,6 @@ class TestDrainMixwal2:
         async with persistent.asession() as sess:
             log = (await sess.exec(select(persistent.ConversationLog))).all()
             assert len(log) == 1
-
-    @pytest.mark.asyncio
-    async def test_skips_write_mw_for_missing_courier(self, fake_thinclient):
-        setup = await _set_up_write_flow(fake_thinclient)
-        # Change the mw.destination to a courier that doesn't exist.
-        async with persistent.asession() as sess:
-            mw = await sess.get(persistent.MixWAL, setup["mw_id"])
-            mw.destination = b"\x99" * 32
-            sess.add(mw)
-            await sess.commit()
-        getattr(network, "__resend_queue_populated").set()
-        getattr(network, "__mixwal_updated").set()
-        getattr(network, "__mixnet_connected").set()
-
-        async def loop_idle():
-            # Give the loop a chance to process and skip.
-            return network.drain_mixwal2 is not None  # always truthy
-
-        # Run a short tick: shutdown after a few yields.
-        async def quitter():
-            for _ in range(40):
-                await asyncio.sleep(0)
-            network.shutdown()
-
-        asyncio.create_task(quitter())
-        try:
-            await asyncio.wait_for(
-                network.drain_mixwal2(fake_thinclient), timeout=3.0,
-            )
-        except asyncio.TimeoutError:
-            pass
-        # MW still present (skipped, not drained).
-        async with persistent.asession() as sess:
-            assert await sess.get(persistent.MixWAL, setup["mw_id"]) is not None
-        assert fake_thinclient.call_count("start_resending_encrypted_message") == 0
-
 
 # ---------------------------------------------------------------------------
 # readables_to_mixwal


### PR DESCRIPTION
kpclientd owns courier selection and pins it across the two-phase ARQ receive and every retry, and StartResendingEncryptedMessage carries no courier field, so the courier katzenqt picked was never transmitted; worse, courier_destination_exists gated resends on that unused draw and could stall a read 500 seconds when it rotated out of the PKI. Drop the courier picks, the check, and the MixWAL.destination column (with a migration to drop it), plus the tests that asserted the removed behaviour.